### PR TITLE
Move to `hatchling` for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pipx run nox -s build
+      - run: pipx run build

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,9 +12,3 @@ def lint(session):
     session.install(".[lint]")
     session.run("ruff", "check", ".")
     session.run("black", "--check", ".")
-
-
-@nox.session
-def build(session):
-    session.install("flit")
-    session.run("flit", "build")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 
 [project]
 name = "microvenv"


### PR DESCRIPTION
Allows using `build` for building while respecting `.gitignore`, compared to Flit which requires using the `flit` command.