### PR TITLE
Use argparse to parse args

### DIFF
--- a/microvenv.py
+++ b/microvenv.py
@@ -80,6 +80,11 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     default_dir = ".venv"
-    parser.add_argument("env_dir", default=default_dir, nargs="?", help=f"Directory to create virtual environnment in (default: {default_dir!r}")
+    parser.add_argument(
+        "env_dir",
+        default=default_dir,
+        nargs="?",
+        help=f"Directory to create virtual environment in (default: {default_dir!r}",
+    )
     args = parser.parse_args()
     create(args.env_dir)

--- a/microvenv.py
+++ b/microvenv.py
@@ -76,12 +76,9 @@ def create(env_dir=".venv"):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 2:
-        print("Usage: microvenv.py [env_dir='.venv']", file=sys.stderr)
-        sys.exit(1)
-    try:
-        env_dir = sys.argv[1]
-    except IndexError:
-        env_dir = ".venv"
+    import argparse
 
-    create(env_dir)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("env_dir", default=".venv", nargs="?", help="default: '.venv'")
+    args = parser.parse_args()
+    create(args.env_dir)

--- a/microvenv.py
+++ b/microvenv.py
@@ -79,6 +79,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("env_dir", default=".venv", nargs="?", help="default: '.venv'")
+    default_dir = ".venv"
+    parser.add_argument("env_dir", default=default_dir, nargs="?", help=f"Directory to create virtual environnment in (default: {default_dir!r}")
     args = parser.parse_args()
     create(args.env_dir)


### PR DESCRIPTION
I know it's kind of silly, but why not use the standard library argparse? 😊

If we import argparse only when the script is run standalone, it will also not affect performance when other software uses this script as a package.