### PR TITLE
Add support for `scm_ignore_files` (and restructure project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `microvenv/_create.py` file is also small enough to have its contents passed
 
 ## Differences compared to the [`venv` module](https://docs.python.org/3/library/venv.html#module-venv)
 
-The module operates similarly to `py -m venv --symlinks --without-pip .venv`,
+The code operates similarly to `py -m venv --symlinks --without-pip .venv`,
 except that:
 
 - There are no activation scripts (you can execute `python` in the virtual environment directly)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Create a minimal virtual environment.
 
 This module is meant for when the [`venv` module](https://docs.python.org/3/library/venv.html#module-venv) has been removed from the standard library by your Python distribution. Because `venv` is not available on PyPI and is developed in the stdlib, it is not possible to install it using `pip` or simply copy the code and expect it to work with older versions of Python. This module then attempts to be that portable alternative for creating virtual environments.
 
-In general, though, using the [`venv` module](https://docs.python.org/3/library/venv.html#module-venv) should be preferred and this module is only used as a fallback.
+In general, though, using the [`venv` module](https://docs.python.org/3/library/venv.html#module-venv) should be preferred and this module used as a fallback.
 
 
 ## Usage
 
 ```console
-python microvenv.py [env_dir=".venv"]
+python microvenv.py [--without-scm-ignore-files] [env_dir=".venv"]
 ```
 
 If an argument is provided to the script, it is used as the path to create the virtual environment in. Otherwise, the virtual environment is created in `.venv`.
@@ -18,10 +18,10 @@ If an argument is provided to the script, it is used as the path to create the v
 For programmatic usage, there is the `create()` function, which is analogous to the [`venv.create()` function](https://docs.python.org/3/library/venv.html#venv.create).
 
 ```python
-def create(env_dir: os.PathLike[str] | str = ".venv") -> None
+def create(env_dir: os.PathLike[str] | str = ".venv", *, scm_ignore_files={"git"}) -> None
 ```
 
-The `microvenv.py` file is also small enough to have its contents passed in via the `-c` flag to `python`.
+The `microvenv/_create.py` file is also small enough to have its contents passed in via the `-c` flag to `python`.
 
 ## Differences compared to the [`venv` module](https://docs.python.org/3/library/venv.html#module-venv)
 

--- a/microvenv/__init__.py
+++ b/microvenv/__init__.py
@@ -1,0 +1,1 @@
+from ._create import create as create

--- a/microvenv/__main__.py
+++ b/microvenv/__main__.py
@@ -1,0 +1,4 @@
+from ._create import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "microvenv"
-version = "2023.1.2"
+version = "2023.2.0"
 description = "A minimal re-implementation of Python's venv module"
 keywords = ["virtual environments", "venv"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pathlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def executable():
+    return pathlib.Path(sys.executable)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+
+import pytest
+
+import microvenv
+
+
+@pytest.fixture
+def CLI(executable):
+    def _CLI(*args):
+        subprocess.check_call(
+            [os.fsdecode(executable), microvenv._create.__file__, *args]
+        )
+
+    return _CLI
+
+
+@pytest.mark.parametrize(
+    ["args", "expected_dir"], [([], ".venv"), (["some-venv"], "some-venv")]
+)
+def test_relative_path(monkeypatch, tmp_path, args, expected_dir, CLI):
+    """Test using a relative path (both the default and explicitly provided)."""
+    path = tmp_path / expected_dir
+    monkeypatch.chdir(tmp_path)
+    CLI(*args)
+    assert path.is_dir()
+    assert (path / "pyvenv.cfg").is_file()
+
+
+def test_absolute_path(tmp_path, CLI):
+    path = tmp_path / "some-venv"
+    CLI(os.fsdecode(path))
+
+    assert path.is_dir()
+    assert (path / "pyvenv.cfg").is_file()
+
+
+def test_too_many_args(tmp_path, CLI):
+    path = tmp_path / "some-venv"
+    with pytest.raises(subprocess.CalledProcessError):
+        CLI(os.fsdecode(path), "extra-arg")
+
+    assert not path.exists()
+
+
+def test_default_scm_ignore_files(tmp_path, CLI):
+    venv_path = tmp_path / "some-venv"
+    CLI(os.fsdecode(venv_path))
+    gitignore_path = venv_path / ".gitignore"
+
+    assert gitignore_path.is_file()
+    assert gitignore_path.read_text(encoding="utf-8") == "*\n"
+
+
+def test_without_scm_ignore_files(tmp_path, CLI):
+    venv_path = tmp_path / "some-venv"
+    CLI("--without-scm-ignore-files", os.fsdecode(venv_path))
+    gitignore_path = venv_path / ".gitignore"
+
+    assert not gitignore_path.exists()


### PR DESCRIPTION
The primary code for creating a virtual environment now lives in `microvenv/_create.py`.

Closes #43